### PR TITLE
EC2 instance profile needs to list objects.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -61,6 +61,7 @@ module "iam_instance_profile" {
           {
               "Effect": "Allow",
               "Action": [
+                  "s3:ListObjects",
                   "s3:GetObject",
                   "s3:PutObject"
               ],


### PR DESCRIPTION
`GetObject` and `PutObject` will not be sufficient, I missed this in #1.