### PR TITLE
Enable IAM profile to list bucket from top-level.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -54,10 +54,10 @@ module "iam_instance_profile" {
           {
               "Effect": "Allow",
               "Action": [
-                  "s3:ListAllMyBuckets"
+                  "s3:ListBucket",
               ],
-              "Resource": "arn:aws:s3:::*"
-          },
+              "Resource": "arn:aws:s3:::${local.bucket}"
+          }
           {
               "Effect": "Allow",
               "Action": [


### PR DESCRIPTION
I often forget this, but tested one last tweak after #2. We do not
really need ListAllMyBuckets for an instance profile role, and the
reason for ListObjectsV2 access denied is I often forget you need
the policy on arn:aws:s3:::bucketname, not arn:aws:s3:::bucketname/*.

Minor but important difference.