### PR TITLE
Clean up docker-compose init on startup.

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   vuls:
-    image: ohsh6o/vuls:0.9.5-hf1
+    image: vuls/vuls
     command:
       - server
       - -debug

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,8 +2,23 @@ version: '3'
 services:
   vuls:
     image: ohsh6o/vuls:0.9.5-hf1
-    command: > 
-      server -debug -debug-sql -to-localfile -format-json -log-dir=/var/log -results-dir=/vuls/results -listen=0.0.0.0:5515 -cvedb-type=http -cvedb-url=http://cvedb:1323 -ovaldb-type=http -ovaldb-url=http://ovaldb:1324 -gostdb-type=http -gostdb-url=http://gostdb:1325 -explotdb-type=http -exploitdb-url=http://exploitdb:1326
+    command:
+      - server
+      - -debug
+      - -debug-sql
+      - -to-localfile
+      - -format-json
+      - -log-dir=/var/log
+      - -results-dir=/vuls/results
+      - -listen=0.0.0.0:5515
+      - -cvedb-type=http
+      - -cvedb-url=http://cvedb:1323
+      - -ovaldb-type=http
+      - -ovaldb-url=http://ovaldb:1324
+      - -gostdb-type=http
+      - -gostdb-url=http://gostdb:1325
+      - -exploitdb-type=http
+      - -exploitdb-url=http://exploitdb:1326
     volumes:
       - ./vuls:/vuls
       - ./log:/var/log

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,13 +25,13 @@ locals {
     git clone https://github.com/flexion/10x-dux-vuls-eval.git
     chown -R ec2-user:ec2-user 10x-dux-vuls-eval
     pushd 10x-dux-vuls-eval/docker/
-    git checkout tasks/initialize-containers-at-start-with-cloud-init
     pushd vuls/
     for db in cve go-exploitdb gost oval;
     do aws s3 cp s3://10x-dux-dev-vuls-results/$db.sqlite3 .;
     done;
     popd
     aws s3 cp s3://10x-dux-dev-vuls-results/config.toml .
+    docker-compose up -d
     popd
     popd
   USERDATA
@@ -69,7 +69,7 @@ module "iam_instance_profile" {
           {
               "Effect": "Allow",
               "Action": [
-                  "s3:ListBucket",
+                  "s3:ListBucket"
               ],
               "Resource": "arn:aws:s3:::${local.bucket}"
           },

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -72,7 +72,7 @@ module "iam_instance_profile" {
                   "s3:ListBucket",
               ],
               "Resource": "arn:aws:s3:::${local.bucket}"
-          }
+          },
           {
               "Effect": "Allow",
               "Action": [

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,6 +25,7 @@ locals {
     git clone https://github.com/flexion/10x-dux-vuls-eval.git
     chown -R ec2-user:ec2-user 10x-dux-vuls-eval
     pushd 10x-dux-vuls-eval/docker/
+    git checkout tasks/initialize-containers-at-start-with-cloud-init
     pushd vuls/
     for db in cve go-exploitdb gost oval;
     do aws s3 cp s3://10x-dux-dev-vuls-results/$db.sqlite3 .;


### PR DESCRIPTION
There were issues with `docker-compose` being used on the server to build out the server and run all containers on startup. This will fix those issues.