### PR TITLE
Allow network access from cloud.gov network range.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -232,6 +232,17 @@ resource "aws_security_group" "default" {
     self        = true
   }
 
+  ingress {
+    description = "external-vuls"
+    from_port   = 5515
+    to_port     = 5515
+    protocol    = "tcp"
+    cidr_blocks = concat(
+      ["${chomp(data.http.caller_identity_ip.body)}/32"],
+      var.cloudgov_cidrs
+      )
+  }
+
   egress {
     description = "egress-all"
     from_port   = 0

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -51,3 +51,8 @@ variable "private_key_extension" {}
 variable "public_key_extension" {}
 
 variable "ip_lookup_source" {}
+
+variable "cloudgov_cidrs" {
+  type = list
+  default = []
+}


### PR DESCRIPTION
Note: these will need to be passed with plan and apply
commands separately. Such as:

terraform plan -var 'cloudgov_cidrs=["1.2.3.4/32"]'
terraform apply -var 'cloudgov_cidrs=["1.2.3.4/32"]'

We do not want to include NAT'ed external addresses of any cloud.gov
system in our code. If not, it will default to an empty list.