### PR TITLE
Provide empty ./vuls/results dir as needed.

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -65,6 +65,7 @@ services:
       - ./log:/var/log
     ports:
       - "1326:1326"
+
   vulsrepo:
       image: vuls/vulsrepo:latest
       command:


### PR DESCRIPTION
With the addition of vulsrepo UI in #9, I was able to debug further some
issues encountered when using docker-compose in local setups. This is
because the existing server deployment had this folder existing. Without
it, debugging the container, you get messages like this.

2020/06/10 03:32:56 main.go:153: INFO: RootPath Load:  /vulsrepo/www
2020/06/10 03:32:56 main.go:157: Error: ResultsPath not access:  stat /vuls/results: no such file or directory
2020/06/10 03:32:56 main.go:190: Error: Please see if the config setting is correct

So if other services have not received data, you will keep getting this issue.