### PR TITLE
Fix vuls test server to install vuls binary

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,6 @@
 locals {
   bucket                 = "${var.namespace}-${var.stage}-${var.name}-results"
-  vuls_release           = "0.9.6"
+  vuls_release           = "0.11.0"
   base_userdata          = <<-USERDATA
     #!/bin/bash
     cat <<"__EOF__" > /home/ec2-user/.ssh/config

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -38,6 +38,10 @@ locals {
   USERDATA
   test_userdata          = <<-USERDATA
     ${local.base_userdata}
+    curl -L -o /tmp/vuls.tar.gz https://github.com/future-architect/vuls/releases/download/v${local.vuls_release}/vuls_${local.vuls_release}_linux_amd64.tar.gz
+    tar -C /usr/local/bin -xf /tmp/vuls.tar.gz vuls
+    chmod +x /usr/local/bin/vuls
+    rm /tmp/vuls.tar.gz
     su - ec2-user <<"__EOF__"
     aws s3 cp s3://10x-dux-dev-vuls-results/config.toml .
     git clone https://github.com/flexion/10x-dux-app


### PR DESCRIPTION
So this seems to be lost somewhere, but the binary is not getting bootstrapped like I presumed it was. We need to test some updates out-of-band from CloudFoundry for now.