### PR TITLE
[docker] Use our forked container build

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   vuls:
-    image: vuls/vuls:0.11.0
+    image: ohsh6o/vuls:v0.11.1-alpha
     command:
       - server
       - -debug


### PR DESCRIPTION
It has our properly dockerized environment in the eval area match [our tagged eval branch](https://github.com/ohsh6o/vuls/releases/tag/v0.11.1-alpha).